### PR TITLE
Move to environment hook

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -2,6 +2,5 @@
 
 set -euo pipefail
 
-echo '--- Skipping git checkout'
-
+echo 'Skipping git checkout'
 export BUILDKITE_REPO=""

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "${BATS_PLUGIN_PATH}/load.bash"
 
 @test "Runs successfully" {
-  run "$PWD/hooks/pre-checkout"
+  run "$PWD/hooks/environment"
 
   assert_success
   # `run` works in a subshell, so env vars aren't available to test. Can't work out how to verify this


### PR DESCRIPTION
The global pre-checkout hook runs before plugins, so we need this plugin to run even earlier to make sure that `BUILDKITE_REPO` is blanked out before the global pre-checkout hook.